### PR TITLE
fix: preload icon css to fix resizing bug

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,6 +7,10 @@ import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
+import '@fortawesome/fontawesome-svg-core/styles.css';
+import { config } from '@fortawesome/fontawesome-svg-core';
+config.autoAddCss = false;
+
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
   return (


### PR DESCRIPTION
apparently you need to preload css to avoid resizing static content 
https://github.com/FortAwesome/react-fontawesome/issues/134