### PR TITLE
enhance: customize the next version label

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,6 +62,11 @@ const config = {
           routeBasePath: "/",
           editUrl:
             'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+          versions: {
+            current: {
+              label: `Current 🚧`,
+            },
+          },
         },
         blog: {
           showReadingTime: true,
@@ -120,7 +125,7 @@ const config = {
               type: 'docsVersionDropdown',
               label: 'version',
               position: 'right',
-              dropdownItemsAfter: [{to: '/versions', label: 'All versions'}],
+              dropdownItemsAfter: [{ to: '/versions', label: 'All versions' }],
               dropdownActiveClassDisabled: true,
             },
             {
@@ -144,12 +149,12 @@ const config = {
 function modifyContent(filename, content) {
   const titleMatch = content.match(/^#\s*(.+)/);
   if (titleMatch && titleMatch[1]) {
-      filename = `${titleMatch[1]}.md`;
+    filename = `${titleMatch[1]}.md`;
   }
 
   return {
-      filename: filename,
-      content: content,
+    filename: filename,
+    content: content,
   };
 }
 


### PR DESCRIPTION
tweaks the dropdown label for the upcoming docs version 

<img width="583" alt="Screenshot 2024-12-16 at 4 24 37 PM" src="https://github.com/user-attachments/assets/90d0650d-e2cd-4696-9c43-0cb7856c76bd" />
