### PR TITLE
fix: change homepage title prefix to Docs

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -36,7 +36,7 @@ export default function Home() {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
+      title={`Docs`}
       description="Description will go into a meta tag in <head />">
       <HomepageHeader />
       <main>


### PR DESCRIPTION
updating the `title` for the Home page so that it reads better in the browser tab

### Before
<img width="281" alt="Screenshot 2024-12-19 at 2 35 47 PM" src="https://github.com/user-attachments/assets/759af070-2538-4560-bacf-392de7e36556" />

### After
<img width="290" alt="Screenshot 2024-12-19 at 2 29 46 PM" src="https://github.com/user-attachments/assets/350e30c8-bff2-4f98-8fd3-13204e38fc0c" />
