### PR TITLE
fix: enable vault secrets plugin and fix docker links

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -37,7 +37,7 @@ steps:
 
 Building an image with elevated access is a allowed pattern as long as the administrators have set the required allow list of images on the worker. It's *important to work with your administrator* to understand stand which pattern you instances was deployed to support. The supported plugin for building those images:
 
-* [vela-docker](/docs/usage/plugins/registry/docker.md)
+* [vela-docker](/docs/usage/plugins/registry/docker)
 
 ```yaml
 version: "1"

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -37,7 +37,7 @@ steps:
 
 Building an image with elevated access is a allowed pattern as long as the administrators have set the required allow list of images on the worker. It's *important to work with your administrator* to understand stand which pattern you instances was deployed to support. The supported plugin for building those images:
 
-* [vela-docker](/docs/usage/plugins/registry/docker)
+* [vela-docker](/docs/usage/plugins/registry/Docker.md)
 
 ```yaml
 version: "1"

--- a/docs/usage/examples/secrets_external.md
+++ b/docs/usage/examples/secrets_external.md
@@ -31,7 +31,7 @@ The following [pipeline concepts](/docs/usage/tour/tour.md) are being used in th
 
 The following [Vela plugins](/docs/usage/tour/tour.md) are being used in the pipeline below:
 
-* [Docker](/docs/usage/plugins/registry/docker.md)
+* [Docker](/docs/usage/plugins/registry/docker)
 
 :::tip
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`
@@ -88,7 +88,7 @@ The following [pipeline concepts](/docs/usage/tour/tour.md) are being used in th
 
 The following [Vela plugins](/docs/usage/tour/tour.md) are being used in the pipeline below:
 
-* [Docker](/docs/usage/plugins/registry/docker.md)
+* [Docker](/docs/usage/plugins/registry/docker)
 
 :::tip
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`

--- a/docs/usage/examples/secrets_external.md
+++ b/docs/usage/examples/secrets_external.md
@@ -31,7 +31,7 @@ The following [pipeline concepts](/docs/usage/tour/tour.md) are being used in th
 
 The following [Vela plugins](/docs/usage/tour/tour.md) are being used in the pipeline below:
 
-* [Docker](/docs/usage/plugins/registry/docker)
+* [Docker](/docs/usage/plugins/registry/Docker.md)
 
 :::tip
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`
@@ -88,7 +88,7 @@ The following [pipeline concepts](/docs/usage/tour/tour.md) are being used in th
 
 The following [Vela plugins](/docs/usage/tour/tour.md) are being used in the pipeline below:
 
-* [Docker](/docs/usage/plugins/registry/docker)
+* [Docker](/docs/usage/plugins/registry/Docker.md)
 
 :::tip
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`

--- a/docs/usage/examples/secrets_internal.md
+++ b/docs/usage/examples/secrets_internal.md
@@ -35,7 +35,7 @@ The following [pipeline concepts](/docs/usage/tour/tour.md) are being used in th
 
 The following [Vela plugins](/docs/usage/tour/tour.md) are being used in the pipeline below:
 
-* [Docker](/docs/usage/plugins/registry/docker)
+* [Docker](/docs/usage/plugins/registry/Docker.md)
 
 :::tip
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`
@@ -82,7 +82,7 @@ The following [pipeline concepts](/docs/usage/tour/tour.md) are being used in th
 
 The following [Vela plugins](/docs/usage/tour/tour.md) are being used in the pipeline below:
 
-* [Docker](/docs/usage/plugins/registry/docker)
+* [Docker](/docs/usage/plugins/registry/Docker.md)
 
 :::tip
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`

--- a/docs/usage/examples/secrets_internal.md
+++ b/docs/usage/examples/secrets_internal.md
@@ -35,7 +35,7 @@ The following [pipeline concepts](/docs/usage/tour/tour.md) are being used in th
 
 The following [Vela plugins](/docs/usage/tour/tour.md) are being used in the pipeline below:
 
-* [Docker](/docs/usage/plugins/registry/docker.md)
+* [Docker](/docs/usage/plugins/registry/docker)
 
 :::tip
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`
@@ -82,7 +82,7 @@ The following [pipeline concepts](/docs/usage/tour/tour.md) are being used in th
 
 The following [Vela plugins](/docs/usage/tour/tour.md) are being used in the pipeline below:
 
-* [Docker](/docs/usage/plugins/registry/docker.md)
+* [Docker](/docs/usage/plugins/registry/docker)
 
 :::tip
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`

--- a/remote-vela-plugins/plugins.js
+++ b/remote-vela-plugins/plugins.js
@@ -139,12 +139,12 @@ const remoteVelaPlugins = [
         sourceRef: "refs/heads/main",
         sourceFileName: "DOCS.md",
     },
-    // {
-    //     name: "vault-secrets",
-    //     sourceRepo: "go-vela/secret-vault",
-    //     sourceRef: "refs/heads/main",
-    //     sourceFileName: "DOCS.md",
-    // },
+    {
+        name: "vault-secrets",
+        sourceRepo: "go-vela/secret-vault",
+        sourceRef: "refs/heads/main",
+        sourceFileName: "DOCS.md",
+    },
 ]
 
 export default remoteVelaPlugins;


### PR DESCRIPTION
not sure why, but i can only reference vela-docker using the page title `Docker` and not filename `docker.md` :shrug: