### PR TITLE
fix: handle more formatting for remote plugin docs

### DIFF
--- a/remote-vela-plugins/utils.js
+++ b/remote-vela-plugins/utils.js
@@ -97,6 +97,12 @@ function modifyRemoteContent(plugin) {
         content = content.replace(/<repo>/g, "|repo|");
         content = content.replace(/<org>/g, "|org|");
 
+        // Convert angle bracket URLs to proper markdown links
+        // This matches <http://...> or <https://...> patterns and converts them to [url](url)
+        content = content.replace(/<(https?:\/\/[^>]+)>/g, function(match, url) {
+            return `[${url}](${url})`;
+        });
+
         return {
             filename: filename,
             content: content,


### PR DESCRIPTION
docs are currently not building, in part due to this. K6 docs have added formatting for links to be enclosed by `<` `>`. this should handle that scenario.

error from previous build:
```
Error: MDX compilation failed for file "/home/runner/work/docs/docs/docs/usage/plugins/registry/K6.md"
Cause: Unexpected character `/` (U+002F) before local name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a link in MDX, use `[text](url)`)
```