### PR TITLE
Fix token extraction in OpenID Connect usage

### DIFF
--- a/docs/usage/open_id_connect.md
+++ b/docs/usage/open_id_connect.md
@@ -50,7 +50,7 @@ steps:
         - >
             AUTH_TOKEN=$(curl -H "Authorization: Bearer $VELA_ID_TOKEN_REQUEST_TOKEN"
             "$VELA_ID_TOKEN_REQUEST_URL?audience=artifactory" |
-            jq -r '.value')
+            jq -r '.token')
         - >
             REQ=$(curl -s -X POST -H "Token: $AUTH_TOKEN"
             "https://cloud-service-open-id-validator.com/get-token")


### PR DESCRIPTION
Per the API [here](https://github.com/go-vela/server/blob/main/api/types/token.go#L11), the correct value is `token` not `value`.

Also the API claims to return `expiration`, but that doesn't seem to be the case.